### PR TITLE
Variable size never read

### DIFF
--- a/ncx_slab.c
+++ b/ncx_slab.c
@@ -165,7 +165,6 @@ ncx_slab_alloc_locked(ncx_slab_pool_t *pool, size_t size)
         slot = shift - pool->min_shift;
 
     } else {
-        size = pool->min_size;
         shift = pool->min_shift;
         slot = 0;
     }


### PR DESCRIPTION
Value stored to size is never read.
Unnecessary statement removed.